### PR TITLE
Fix --umask

### DIFF
--- a/bin/pysftpjail
+++ b/bin/pysftpjail
@@ -15,8 +15,8 @@ def main():
                         help='the path of the chroot jail')
     parser.add_argument('--logfile', '-l', dest='logfile',
                         help='path to the logfile')
-    parser.add_argument('--umask', '-u', dest='umask',
-                        help='set the umask of the SFTP server')
+    parser.add_argument('--umask', '-u', dest='umask', type=int,
+                        help='set the umask of the SFTP server (note: decimal value expected)')
 
     args = parser.parse_args()
     SFTPServer(


### PR DESCRIPTION
Python's `os.umask()` requires an integer.  Without conversion, argparse captures a str and a `TypeError` gets thrown.  E.g. `pysftpjail --umask 23 /path/to/chroot`.